### PR TITLE
Support RC2/RC3 of scala3

### DIFF
--- a/src/main/scala/domain.scala
+++ b/src/main/scala/domain.scala
@@ -27,6 +27,8 @@ sealed abstract class ScalaVersion(val raw: String)
     case Scala213   => Some(Scala212)
     case Scala3_M3  => Some(Scala213)
     case Scala3_RC1 => Some(Scala3_M3)
+    case Scala3_RC2 => Some(Scala3_RC1)
+    case Scala3_RC3 => Some(Scala3_RC2)
   }
 }
 case object Scala211 extends ScalaVersion("2.11")
@@ -35,6 +37,8 @@ case object Scala212   extends ScalaVersion("2.12")
 case object Scala213   extends ScalaVersion("2.13")
 case object Scala3_M3  extends ScalaVersion("3.0.0-M3")
 case object Scala3_RC1 extends ScalaVersion("3.0.0-RC1")
+case object Scala3_RC2 extends ScalaVersion("3.0.0-RC2")
+case object Scala3_RC3 extends ScalaVersion("3.0.0-RC3")
 
 object ScalaVersion {
   def unapply(s: String): Option[ScalaVersion] = s match {
@@ -43,6 +47,8 @@ object ScalaVersion {
     case "2.11"      => Option(Scala211)
     case "3.0.0-M3"  => Option(Scala3_M3)
     case "3.0.0-RC1" => Option(Scala3_RC1)
+    case "3.0.0-RC2" => Option(Scala3_RC2)
+    case "3.0.0-RC3" => Option(Scala3_RC3)
   }
 }
 


### PR DESCRIPTION
Hopefully that's all there is to it...

Seems to work on [slang](https://github.com/kubukoz/slang):

```
coursier launch com.indoorvivants::razoryak:0.0.2+2-ed806260-SNAPSHOT -- com.kubukoz slang --scala 3.0.0-RC3
[+] Trying to retrieve dependencies from Artifact(false,com.kubukoz,slang,Axis(Scala3_RC2,JVM))
[+] We will construct com.kubukoz:slang_3.0.0-RC3:<FUTURE> by checking the dependencies of com.kubukoz:slang_3.0.0-RC2:0.1.0-SNAPSHOT
[+] Trying to retrieve dependencies from Artifact(false,co.fs2,fs2-core,Axis(Scala3_RC2,JVM))
[+] We will construct co.fs2:fs2-core_3.0.0-RC3:<FUTURE> by checking the dependencies of co.fs2:fs2-core_3.0.0-RC2:3.0.1
[+] Trying to retrieve dependencies from Artifact(false,org.typelevel,cats-parse,Axis(Scala3_RC2,JVM))
[+] We will construct org.typelevel:cats-parse_3.0.0-RC3:<FUTURE> by checking the dependencies of org.typelevel:cats-parse_3.0.0-RC2:0.3.2
[+] Trying to retrieve dependencies from Artifact(false,com.kubukoz,debug-utils,Axis(Scala3_RC2,JVM))
[+] We will construct com.kubukoz:debug-utils_3.0.0-RC3:<FUTURE> by checking the dependencies of com.kubukoz:debug-utils_3.0.0-RC2:1.1.1
[+] Trying to retrieve dependencies from Artifact(false,com.github.julien-truffaut,monocle-core,Axis(Scala3_RC2,JVM))
[+] We will construct com.github.julien-truffaut:monocle-core_3.0.0-RC3:<FUTURE> by checking the dependencies of com.github.julien-truffaut:monocle-core_3.0.0-RC2:3.0.0-M4
[+] Trying to retrieve dependencies from Artifact(false,co.fs2,fs2-io,Axis(Scala3_RC2,JVM))
[+] We will construct co.fs2:fs2-io_3.0.0-RC3:<FUTURE> by checking the dependencies of co.fs2:fs2-io_3.0.0-RC2:3.0.1
[+] Trying to retrieve dependencies from Artifact(false,com.comcast,ip4s-core,Axis(Scala3_RC2,JVM))
[+] We will construct com.comcast:ip4s-core_3.0.0-RC3:<FUTURE> by checking the dependencies of com.comcast:ip4s-core_3.0.0-RC2:3.0.1
[ ] Upgrade to org.scodec:scodec-bits_3.0.0-RC3:1.1.26 from 1.1.25
[ ] Upgrade to org.typelevel:cats-effect_3.0.0-RC3:3.1.0 from 3.0.1
[ ] Upgrade to org.typelevel:cats-effect-kernel_3.0.0-RC3:3.1.0 from 3.0.1
[ ] Upgrade to org.typelevel:cats-kernel_3.0.0-RC3:2.6.0 from 2.5.0
[ ] Upgrade to org.typelevel:cats-core_3.0.0-RC3:2.6.0 from 2.5.0
[x] Use org.typelevel:simulacrum-scalafix-annotations_3.0.0-RC3:0.5.4
[ ] Upgrade to org.typelevel:cats-effect-std_3.0.0-RC3:3.1.0 from 3.0.1
[ ] Publish co.fs2:fs2-core_3.0.0-RC3: for Axis(Scala3_RC3,JVM)
[ ] Publish org.typelevel:cats-parse_3.0.0-RC3: for Axis(Scala3_RC3,JVM)
[ ] Upgrade to org.typelevel:literally_3.0.0-RC3:1.0.1 from 1.0.0
[ ] Publish com.kubukoz:debug-utils_3.0.0-RC3: for Axis(Scala3_RC3,JVM)
[ ] Upgrade to org.typelevel:cats-free_3.0.0-RC3:2.6.0 from 2.5.0
[ ] Publish com.github.julien-truffaut:monocle-core_3.0.0-RC3: for Axis(Scala3_RC3,JVM)
[ ] Publish com.comcast:ip4s-core_3.0.0-RC3: for Axis(Scala3_RC3,JVM)
[ ] Publish co.fs2:fs2-io_3.0.0-RC3: for Axis(Scala3_RC3,JVM)
[ ] Publish com.kubukoz:slang_3.0.0-RC3: for Axis(Scala3_RC3,JVM)
```